### PR TITLE
Switch to using mdnsjs as the first available lib

### DIFF
--- a/src/mdns.js
+++ b/src/mdns.js
@@ -22,15 +22,15 @@ export default class {
 
   _findLibrary() {
     try {
-      const mdns = require('mdns');
-      this.libraryName = 'mdns';
+      const mdns = require('mdnsjs');
+      this.libraryName = 'mdnsjs';
       return mdns;
     } catch (e) {
       // who cares
     }
     try {
-      const mdnsjs = require('mdns-js');
-      this.libraryName = 'mdnsjs';
+      const mdnsjs = require('mdns');
+      this.libraryName = 'mdns';
       return mdnsjs;
     } catch (e) {
       // who cares


### PR DESCRIPTION
Testing the waters to see if switching to mdns-js as primary will be as detrimental as we originally thought. The on going thought is that machines with bonjour/avahi already installed will cause issues
with the JS version, however I tested on my system and it seems to work without error.

/cc @MarshallOfSound 
