### PR TITLE
Fix error when apple tv is on network: Uncaught TypeError: Cannot rea…

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -72,10 +72,10 @@ export default class extends Emitter {
       networkInterface: service.networkInterface,
       port: service.port,
     };
-    normalized.name = service.name || service.fullname.substring(0, service.fullname.indexOf('.'));
+    normalized.name = service.name || (service.fullname && service.fullname.substring(0, service.fullname.indexOf('.')));
     normalized.txtRecord = service.txtRecord || (() => {
       const records = {};
-      service.txt.forEach((item) => {
+      (service.txt || []).forEach((item) => {
         const key = item.substring(0, item.indexOf('='));
         const value = item.substring(item.indexOf('=') + 1);
         records[key] = value;


### PR DESCRIPTION
When there is an apple tv on the network the browser.js script throws an error on the service fullname and txt values since they are null.  This safely checks those values to prevent the error.

```
node-mdns-easy/dist/browser.js:96 Uncaught TypeError: Cannot read property 'substring' of undefined
    at _class._normalizeService (node_modules/electron-chromecast/node_modules/node-mdns-easy/dist/browser.js:96)
    at _class.serviceUp node_modules/electron-chromecast/node_modules/node-mdns-easy/dist/browser.js:74)
    at module.exports.emit (events.js:223)
    at module.exports.internal.onMessage (node_modules/mdns-js/lib/browser.js:108)
    at module.exports.emit (events.js:223)
    at Socket.<anonymous> (node_modules/mdns-js/lib/networking.js:144)
    at Socket.emit (events.js:223)
    at UDP.onMessage [as onmessage] (dgram.js:874)
```